### PR TITLE
Update logstash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# PayScale #
+
+We are working off the version 2.x branch. In order for kafka offsets to correctly commit we need to be using version .8 of the kafka consumer api, while being compatible with logstash 5.6.x.
+
 # Logstash Plugin
 
 [![Travis Build Status](https://travis-ci.org/logstash-plugins/logstash-input-kafka.svg)](https://travis-ci.org/logstash-plugins/logstash-input-kafka)

--- a/lib/logstash/inputs/kafka.rb
+++ b/lib/logstash/inputs/kafka.rb
@@ -203,12 +203,12 @@ class LogStash::Inputs::Kafka < LogStash::Inputs::Base
       @codec.decode("#{message_and_metadata.message}") do |event|
         decorate(event)
         if @decorate_events
-          event['kafka'] = {'msg_size' => message_and_metadata.message.size,
+          event.set('kafka', {'msg_size' => message_and_metadata.message.size,
                             'topic' => message_and_metadata.topic,
                             'consumer_group' => @group_id,
                             'partition' => message_and_metadata.partition,
                             'offset' => message_and_metadata.offset,
-                            'key' => message_and_metadata.key}
+                            'key' => message_and_metadata.key} )
         end
         output_queue << event
       end # @codec.decode

--- a/logstash-input-kafka.gemspec
+++ b/logstash-input-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-kafka'
-  s.version         = '2.1.0'
+  s.version         = '2.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'This input will read events from a Kafka topic. It uses the high level consumer API provided by Kafka to read messages from the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { 'logstash_plugin' => 'true', 'group' => 'input'}
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api"
   s.add_runtime_dependency 'logstash-codec-json'
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1.0'


### PR DESCRIPTION
Update version 2.x to be compatible with logstash 5.6.x. We need kafka consumer api version .8 which is what this version supports.